### PR TITLE
fix: PEP 621 compliant pyproject; editable install works

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,6 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 
-[project.urls]
-Homepage = "https://github.com/alwaysgreen-ci/alwaysgreen"
-Repository = "https://github.com/alwaysgreen-ci/alwaysgreen"
-Issues = "https://github.com/alwaysgreen-ci/alwaysgreen/issues"
-Documentation = "https://github.com/alwaysgreen-ci/alwaysgreen/tree/main/docs"
-
-[project]
 dependencies = [
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
@@ -43,6 +36,13 @@ dependencies = [
     "GitPython>=3.1.0",
     "PyYAML>=6.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/alwaysgreen-ci/alwaysgreen"
+Repository = "https://github.com/alwaysgreen-ci/alwaysgreen"
+Issues = "https://github.com/alwaysgreen-ci/alwaysgreen/issues"
+Documentation = "https://github.com/alwaysgreen-ci/alwaysgreen/tree/main/docs"
+
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,16 @@ Repository = "https://github.com/alwaysgreen-ci/alwaysgreen"
 Issues = "https://github.com/alwaysgreen-ci/alwaysgreen/issues"
 Documentation = "https://github.com/alwaysgreen-ci/alwaysgreen/tree/main/docs"
 
-[project.dependencies]
-pydantic = ">=2.0.0"
-python-dotenv = ">=1.0.0"
-httpx = ">=0.25.0"
-typer = {extras = ["all"], version = ">=0.9.0"}
-rich = ">=13.0.0"
-GitPython = ">=3.1.0"
-PyYAML = ">=6.0"
+[project]
+dependencies = [
+    "pydantic>=2.0.0",
+    "python-dotenv>=1.0.0",
+    "httpx>=0.25.0",
+    "typer[all]>=0.9.0",
+    "rich>=13.0.0",
+    "GitPython>=3.1.0",
+    "PyYAML>=6.0",
+]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This PR fixes invalid pyproject configuration so installs from source succeed.\n\nChanges:\n- Move dependencies to PEP 621-compliant `[project].dependencies` array\n- Remove duplicate `[project]` header\n\nTested:\n- Editable install in py3.12 venv\n- CLI entrypoint resolves (further missing modules can be addressed in follow-ups)